### PR TITLE
Add a way to disable the default cloud-controller. Also fixes the Jinja2 template for agent nodes.

### DIFF
--- a/inventory
+++ b/inventory
@@ -6,7 +6,6 @@ localhost ansible_connection=local ansible_python_interpreter=python3
 # node2_ip rke2_type="server"
 # node3_ip rke2_type="server"
 
-
 [agents]
 # node4_ip rke2_type="agent"
 # node5_ip rke2_type="agent"

--- a/roles/rke2/templates/config.yaml.j2
+++ b/roles/rke2/templates/config.yaml.j2
@@ -27,7 +27,5 @@ cluster-cidr: {{ rke2_cluster_cidr }}
 {% if rke2_service_cidr is defined %}
 service-cidr: {{ rke2_service_cidr}}
 {% endif %}
-{% if rke2_disable_cloud_controller is defined %}
-disable-cloud-controller: true
-{% endif %}
+disable-cloud-controller: {{ rke2_disable_cloud_controller }}
 {% endif %}

--- a/roles/rke2/templates/config.yaml.j2
+++ b/roles/rke2/templates/config.yaml.j2
@@ -26,3 +26,6 @@ cluster-cidr: {{ rke2_cluster_cidr }}
 {% if rke2_service_cidr is defined %}
 service-cidr: {{ rke2_service_cidr}}
 {% endif %}
+{% if rke2_disable_cloud_controller is defined %}
+disable-cloud-controller: true
+{% endif %}

--- a/roles/rke2/templates/config.yaml.j2
+++ b/roles/rke2/templates/config.yaml.j2
@@ -20,11 +20,13 @@ disable: {{ rke2_disable }}
 kube-apiserver-arg: {{ rke2_apiserver_args}}
 {% endif %}
 snapshotter: {{ rke2_containerd_snapshooter }}
+{% if rke2_type == 'server' %}
 {% if rke2_cluster_cidr is defined %}
 cluster-cidr: {{ rke2_cluster_cidr }}
 {% endif %}
 {% if rke2_service_cidr is defined %}
 service-cidr: {{ rke2_service_cidr}}
+{% endif %}
 {% endif %}
 {% if rke2_disable_cloud_controller is defined %}
 disable-cloud-controller: true

--- a/roles/rke2/templates/config.yaml.j2
+++ b/roles/rke2/templates/config.yaml.j2
@@ -27,7 +27,7 @@ cluster-cidr: {{ rke2_cluster_cidr }}
 {% if rke2_service_cidr is defined %}
 service-cidr: {{ rke2_service_cidr}}
 {% endif %}
-{% endif %}
 {% if rke2_disable_cloud_controller is defined %}
 disable-cloud-controller: true
+{% endif %}
 {% endif %}

--- a/vars/general-config.yml
+++ b/vars/general-config.yml
@@ -54,4 +54,4 @@ rke2_cluster_cidr: 10.42.0.0/16
 rke2_service_cidr: 10.43.0.0/16
 
 # Override default rke2 cloud controller
-# rke2_disable_cloud_controller: true
+rke2_disable_cloud_controller: false

--- a/vars/general-config.yml
+++ b/vars/general-config.yml
@@ -1,6 +1,6 @@
 ---
 
-# node(s) specifications can be define in inventory file
+# node(s) specifications can be defined in inventory file
 
 # SSH user
 ssh_user: ubuntu
@@ -8,7 +8,7 @@ ssh_user: ubuntu
 # SSH Key
 ssh_key_path: /app/id_rsa
 
-# RKE2 installation method (for cross installation only supoport tar)
+# RKE2 installation method (for cross installation, only supports tar)
 rke2_method: tar
 
 # RKE2 version 
@@ -20,7 +20,7 @@ rke2_channel: stable
 # RKE2 repository URL
 rke2_channel_url: https://update.rke2.io/v1-release/channels
 
-# HA mode - disabled, keepalived, external LB (aws, gcp, azure or differen LB's)
+# HA mode - disabled, keepalived, external LB (aws, gcp, azure or different LB's)
 rke2_lb_mode: disabled
 
 # API Server port
@@ -52,3 +52,6 @@ rke2_cluster_cidr: 10.42.0.0/16
 
 # Override default service cidr range
 rke2_service_cidr: 10.43.0.0/16
+
+# Override default rke2 cloud controller
+# rke2_disable_cloud_controller: true


### PR DESCRIPTION
The first change is a way to disable the default cloud controller. The second change concerns the rke2 config template when we change the cluster and service CIDRs. The template should only include these parameters for master nodes otherwise rke2-agents fail to start on worker nodes.