### PR TITLE
servers which are specified in inventory, added to tls-san argument f…

### DIFF
--- a/roles/rke2/templates/config.yaml.j2
+++ b/roles/rke2/templates/config.yaml.j2
@@ -31,4 +31,7 @@ disable-cloud-controller: {{ rke2_disable_cloud_controller }}
 {% if rke2_type == 'server' %}
 tls-san:
   - cluster.local
+{% for host in groups['servers'] %}
+  - {{ host }}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
…or accessing outside of cluster.

tls-san argumanına, server'ların ipleri verilmezse, server nodeları haricinde bir yerden erişmeye çalışıldığında, sertifika'da nodeların ipleri(dış?) var olmadığından problem oluşabiliyor. bu for döngüsü ise, inventoryde serverda belirtilen node iplerini tls san a ekliyor