### PR TITLE
fixed getting api ip

### DIFF
--- a/roles/pre/tasks/main.yml
+++ b/roles/pre/tasks/main.yml
@@ -9,10 +9,12 @@
 
 - name: public fact
   set_fact:
-    rke2_api_ip: groups.servers.0
+    rke2_api_ip: "{{ groups.servers.0 }}"
 
 - name: Populate services facts
   ansible.builtin.service_facts:
+  when:
+    - rke2_lb_mode
 
 - name: Check RKE2 version
   ansible.builtin.shell: |


### PR DESCRIPTION
The configuration file of the cilium was configuring like this;
```
root@ip-10-0-1-10:/home/ubuntu# cat /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
# /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-cilium
  namespace: kube-system
spec:
  valuesContent: |-
    kubeProxyReplacement: strict
    k8sServiceHost: **groups.servers.0**
    k8sServicePort: 6443
    cni:
      chainingMode: "none"
    bpf:
      masquerade: true
```
There should be an ip address instead of `groups.servers.0`
